### PR TITLE
Feat/project name variable

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -477,6 +477,9 @@ module.exports =
       return targetPath
 
     [projectPath, ...] = atom.project.relativizePath(filepath)
+    if not projectPath
+      return targetPath
+
     projectName = path.parse(projectPath).name
     resolvedPath = targetPath.replace(/\$PROJECT_NAME/i, projectName)
     return resolvedPath

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -247,10 +247,10 @@ module.exports =
 
     # Load the fast parser flag in a local variable so that the next scope can access it.
     fastParser = @fastParser
-
+    executablePath = @resolvePath @executablePath
     # We call the mypy process and parse its output.
-    ## For debug: ## alert(@executablePath + " " + params.join(" "))
-    return helpers.exec(@executablePath, params, options).then ((file) ->
+    ## For debug: ## alert(executablePath + " " + params.join(" "))
+    return helpers.exec(executablePath, params, options).then ((file) ->
       # The "file" variable contains the raw mypy output.
       # The goal of this method is to return a string where each line is a valid warning in the format: "FILEPATH:LINENO:COLNO:MESSAGE"
       result = ""
@@ -294,7 +294,7 @@ module.exports =
           2- Offer him a link to change the setting.
         ###
         notification = atom.notifications.addWarning(
-          "The executable of <strong>" + @executablePath + "</strong> was not found.<br />Either install <a href='https://www.python.org/downloads/'>python</a> or adjust the executable path setting of linter-mypy.",
+          "The executable of <strong>" + executablePath + "</strong> was not found.<br />Either install <a href='https://www.python.org/downloads/'>python</a> or adjust the executable path setting of linter-mypy.",
           {
             buttons: [
               {
@@ -325,7 +325,7 @@ module.exports =
           *- Another solution would have been to relaunch the command adapted to a direct call to mypy, but on the long run this would create a support nightmare, this would also mean that for those users two process spawn would be required at every lint, therefore this solution was not implemented.
         ###
         notification = atom.notifications.addWarning(
-          "The executable of <strong>" + @executablePath + "</strong> seems to point to mypy instead of python, please adjust the executable path setting of linter-mypy.",
+          "The executable of <strong>" + executablePath + "</strong> seems to point to mypy instead of python, please adjust the executable path setting of linter-mypy.",
           {
             buttons: [
               {
@@ -351,7 +351,7 @@ module.exports =
           2- Show him an example of command line to install mypy
             * Using to executablePath provided in the settings to build the example will highlight to the user which python installation is being used for users which may have more than one on their system.
         ###
-        atom.notifications.addWarning("The python package <strong>mypy</strong> does not seem to be installed.  Install it with <br /><em>" + @executablePath + " -m pip install mypy</em>")
+        atom.notifications.addWarning("The python package <strong>mypy</strong> does not seem to be installed.  Install it with <br /><em>" + executablePath + " -m pip install mypy</em>")
       else if (0 <= err.message.indexOf("must install the typed_ast package before you can run mypy with"))
         ###
         The Problem: The error is about the absence of the typed_ast module in the python installation.

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -17,7 +17,11 @@ module.exports =
       title: 'Executable Path'
       type: 'string'
       default: 'python3'
-      description: "Path to the executable of python."
+      description: '''Path to the executable of python.
+      An optional `$PROJECT_NAME` variable can be used to resolve the path
+      dynamically depending of the current project's name. For example:
+      `/home/user/.virtualenvs/$PROJECT_NAME/bin/python`.
+      '''
       order: 1
     ignoreFiles:
       type: 'string'

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -470,10 +470,13 @@ module.exports =
           return []
 
   resolvePath: (targetPath) ->
-    projectPaths = atom.project.getPaths()
-    if projectPaths.length > 0
-      projectPath = projectPaths[0]
-      projectName = path.parse(projectPath).name
-      resolvedPath = targetPath.replace(/\$PROJECT_NAME/i, projectName)
+    editor = atom.workspace.getActivePaneItem()
+    filepath = editor?.buffer?.file?.path
 
+    if not filepath
+      return targetPath
+
+    [projectPath, ...] = atom.project.relativizePath(filepath)
+    projectName = path.parse(projectPath).name
+    resolvedPath = targetPath.replace(/\$PROJECT_NAME/i, projectName)
     return resolvedPath

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -464,3 +464,12 @@ module.exports =
         else
           # The file is to be ignored, we therefore return an empty set of warning.
           return []
+
+  resolvePath: (targetPath) ->
+    projectPaths = atom.project.getPaths()
+    if projectPaths.length > 0
+      projectPath = projectPaths[0]
+      projectName = path.parse(projectPath).name
+      resolvedPath = targetPath.replace(/\$PROJECT_NAME/i, projectName)
+
+    return resolvedPath

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -102,7 +102,7 @@ module.exports =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-mypy.executablePath',
       (executablePath) =>
-        @executablePath = @resolvePath executablePath
+        @executablePath = executablePath
     @subscriptions.add atom.config.observe 'linter-mypy.ignoreFiles',
       (ignoreFiles) =>
         @ignoreFiles = ignoreFiles

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -98,7 +98,7 @@ module.exports =
     @subscriptions = new CompositeDisposable
     @subscriptions.add atom.config.observe 'linter-mypy.executablePath',
       (executablePath) =>
-        @executablePath = executablePath
+        @executablePath = @resolvePath executablePath
     @subscriptions.add atom.config.observe 'linter-mypy.ignoreFiles',
       (ignoreFiles) =>
         @ignoreFiles = ignoreFiles

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -8,10 +8,11 @@
 
 LinterMyPystyle = require '../lib/init'
 path = require 'path'
+fs = require 'fs'
 {CompositeDisposable} = require 'atom'
 helpers = require 'atom-linter'
 
-describe "The MyPy provider for Linter", ->
+fdescribe "The MyPy provider for Linter", ->
   lint = require('../lib/init').provideLinter().lint
   beforeEach ->
     waitsForPromise ->
@@ -28,18 +29,22 @@ describe "The MyPy provider for Linter", ->
   describe "resolve the project name variable", ->
 
     beforeEach ->
-      directory = path.join(__dirname, '..')
+      directory = "/tmp/python_project"
+      fs.mkdirSync(directory)
       atom.project.setPaths([directory])
+
+    afterEach ->
+      fs.rmdirSync("/tmp/python_project")
 
     it "should return the project's name when given the variable", ->
       result = LinterMyPystyle.resolvePath("$PROJECT_NAME")
-      # Return this project's name (i.e. linter-mypy)
-      expect(result).toBe("linter-mypy")
+      # Return this project's name (i.e. python_project)
+      expect(result).toBe("python_project")
 
     it "should return the project's name when given a full path", ->
       targetPath = '/home/user/.virtualenvs/$PROJECT_NAME/bin/python'
       result = LinterMyPystyle.resolvePath(targetPath)
-      expectedPath = '/home/user/.virtualenvs/linter-mypy/bin/python'
+      expectedPath = '/home/user/.virtualenvs/python_project/bin/python'
       expect(result).toBe(expectedPath)
 
     it "should return the same path if the variable is not set", ->

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -12,7 +12,7 @@ fs = require 'fs'
 {CompositeDisposable} = require 'atom'
 helpers = require 'atom-linter'
 
-fdescribe "The MyPy provider for Linter", ->
+describe "The MyPy provider for Linter", ->
   lint = require('../lib/init').provideLinter().lint
   beforeEach ->
     waitsForPromise ->

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -29,26 +29,81 @@ describe "The MyPy provider for Linter", ->
   describe "resolve the project name variable", ->
 
     beforeEach ->
-      directory = "/tmp/python_project"
-      fs.mkdirSync(directory)
-      atom.project.setPaths([directory])
+      @firstProjectName = 'first_python_project'
+      @firstProjectPath = '/tmp/' + @firstProjectName
+      fs.mkdirSync(@firstProjectPath)
+      fs.mkdirSync(@firstProjectPath + '/src')
+      @firstFilePath = @firstProjectPath + '/src/first_file.py'
+      fs.closeSync(fs.openSync(@firstFilePath, 'w'))
+
+      @secondProjectName = 'second_python_project'
+      @secondProjectPath = '/tmp/' + @secondProjectName
+      fs.mkdirSync(@secondProjectPath)
+      fs.mkdirSync(@secondProjectPath + '/src')
+      @secondFilePath = @secondProjectPath + '/src/second_file.py'
+      fs.closeSync(fs.openSync(@secondFilePath, 'w'))
+
+      atom.project.setPaths([@firstProjectPath, @secondProjectPath])
 
     afterEach ->
-      fs.rmdirSync("/tmp/python_project")
+      fs.unlinkSync(@firstFilePath)
+      fs.rmdirSync(@firstProjectPath + '/src')
+      fs.rmdirSync(@firstProjectPath)
 
-    it "should return the project's name when given the variable", ->
-      result = LinterMyPystyle.resolvePath("$PROJECT_NAME")
-      # Return this project's name (i.e. python_project)
-      expect(result).toBe("python_project")
+      fs.unlinkSync(@secondFilePath)
+      fs.rmdirSync(@secondProjectPath + '/src')
+      fs.rmdirSync(@secondProjectPath)
 
-    it "should return the project's name when given a full path", ->
+    it "should return the first project's name when given the variable", ->
+      firstProjectName = @firstProjectName
+      firstFilePath = @firstFilePath
+      waitsForPromise ->
+        atom.workspace.open(firstFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath("$PROJECT_NAME")
+          # Return this project's name (i.e. first_python_project)
+          expect(result).toBe(firstProjectName)
+
+    it "should return the second project's name when given the variable", ->
+      secondProjectName = @secondProjectName
+      secondFilePath = @secondFilePath
+      waitsForPromise ->
+        atom.workspace.open(secondFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath("$PROJECT_NAME")
+          # Return this project's name (i.e. second_python_project)
+          expect(result).toBe(secondProjectName)
+
+    it "should return the first project's name when given a full path", ->
+      firstFilePath = @firstFilePath
       targetPath = '/home/user/.virtualenvs/$PROJECT_NAME/bin/python'
-      result = LinterMyPystyle.resolvePath(targetPath)
-      expectedPath = '/home/user/.virtualenvs/python_project/bin/python'
-      expect(result).toBe(expectedPath)
+      expectedPath = '/home/user/.virtualenvs/first_python_project/bin/python'
+      waitsForPromise ->
+        atom.workspace.open(firstFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath(targetPath)
+          expect(result).toBe(expectedPath)
 
-    it "should return the same path if the variable is not set", ->
+    it "should return the second project's name when given a full path", ->
+      secondFilePath = @secondFilePath
+      targetPath = '/home/user/.virtualenvs/$PROJECT_NAME/bin/python'
+      expectedPath = '/home/user/.virtualenvs/second_python_project/bin/python'
+      waitsForPromise ->
+        atom.workspace.open(secondFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath(targetPath)
+          expect(result).toBe(expectedPath)
+
+    it "should return the same path if the variable is not set (first)", ->
+      firstFilePath = @firstFilePath
       targetPath = '/home/user/.virtualenvs/somevenv/bin/python'
-      result = LinterMyPystyle.resolvePath(targetPath)
       expectedPath = '/home/user/.virtualenvs/somevenv/bin/python'
-      expect(result).toBe(expectedPath)
+      waitsForPromise ->
+        atom.workspace.open(firstFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath(targetPath)
+          expect(result).toBe(expectedPath)
+
+    it "should return the same path if the variable is not set (second)", ->
+      secondFilePath = @secondFilePath
+      targetPath = '/home/user/.virtualenvs/somevenv/bin/python'
+      expectedPath = '/home/user/.virtualenvs/somevenv/bin/python'
+      waitsForPromise ->
+        atom.workspace.open(secondFilePath).then (e) ->
+          result = LinterMyPystyle.resolvePath(targetPath)
+          expect(result).toBe(expectedPath)

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -1,0 +1,36 @@
+#!/usr/bin/env coffee
+#
+# This spec file validates:
+#  * The use of $PROJECT_NAME variable in the config path
+#
+#  If it fails:
+#  * Adjust the project_name method
+
+LinterMyPystyle = require '../lib/init'
+path = require 'path'
+{CompositeDisposable} = require 'atom'
+helpers = require 'atom-linter'
+
+describe "The MyPy provider for Linter", ->
+  lint = require('../lib/init').provideLinter().lint
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage('linter-mypy')
+    waitsForPromise ->
+      atom.packages.activatePackage('language-python')
+
+  it 'should be in the package list', ->
+    expect(atom.packages.isPackageLoaded('linter-mypy')).toBe true
+
+  it 'should have activated the package', ->
+    expect(atom.packages.isPackageActive('linter-mypy')).toBe true
+
+  describe "resolve the project name variable", ->
+
+    beforeEach ->
+      waitsForPromise ->
+        mypyPath = atom.config.get('linter-mypy.executablePath')
+
+    it "should return the project's name", ->
+      console.error(mypyPath)
+      expect("hello").toBe("world")

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -11,7 +11,7 @@ path = require 'path'
 {CompositeDisposable} = require 'atom'
 helpers = require 'atom-linter'
 
-describe "The MyPy provider for Linter", ->
+fdescribe "The MyPy provider for Linter", ->
   lint = require('../lib/init').provideLinter().lint
   beforeEach ->
     waitsForPromise ->
@@ -28,9 +28,22 @@ describe "The MyPy provider for Linter", ->
   describe "resolve the project name variable", ->
 
     beforeEach ->
-      waitsForPromise ->
-        mypyPath = atom.config.get('linter-mypy.executablePath')
+      directory = path.join(__dirname, '..')
+      atom.project.setPaths([directory])
 
-    it "should return the project's name", ->
-      console.error(mypyPath)
-      expect("hello").toBe("world")
+    it "should return the project's name when given the variable", ->
+      result = LinterMyPystyle.resolvePath("$PROJECT_NAME")
+      # Return this project's name (i.e. linter-mypy)
+      expect(result).toBe("linter-mypy")
+
+    it "should return the project's name when given a full path", ->
+      targetPath = '/home/user/.virtualenvs/$PROJECT_NAME/bin/python'
+      result = LinterMyPystyle.resolvePath(targetPath)
+      expectedPath = '/home/user/.virtualenvs/linter-mypy/bin/python'
+      expect(result).toBe(expectedPath)
+
+    it "should return the same path if the variable is not set", ->
+      targetPath = '/home/user/.virtualenvs/somevenv/bin/python'
+      result = LinterMyPystyle.resolvePath(targetPath)
+      expectedPath = '/home/user/.virtualenvs/somevenv/bin/python'
+      expect(result).toBe(expectedPath)

--- a/spec/linter-mypy_project_name-spec.coffee
+++ b/spec/linter-mypy_project_name-spec.coffee
@@ -11,7 +11,7 @@ path = require 'path'
 {CompositeDisposable} = require 'atom'
 helpers = require 'atom-linter'
 
-fdescribe "The MyPy provider for Linter", ->
+describe "The MyPy provider for Linter", ->
   lint = require('../lib/init').provideLinter().lint
   beforeEach ->
     waitsForPromise ->


### PR DESCRIPTION
This pull request enables the usage of a $PROJECT_NAME variable in the Executable Path option.

With this, the mypy executable of different virtual environments can be used with a single configuration by following the convention of locating all virtual environments in the same directory (e.g. ~/.virtualenvironments) and name them after each project's name.