### PR TITLE
Allow setting multiple paths to search for Python

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -655,7 +655,7 @@ module.exports =
     ##Strip not necessary separator
     options.env["MYPYPATH"] = options.env["MYPYPATH"].replace(new RegExp("^" + path.delimiter + "+|" + path.delimiter + "+$","g"), '')
 
-    executablePath = @resolvePath @executablePath, filePath
+    executablePath = @resolveMultiPaths @executablePath, filePath
     params = @getMypyCommandLine(filePath, filePathShadow)
     configFileIndex = params.lastIndexOf("--config-file") + 1
     if 0 < configFileIndex
@@ -1052,3 +1052,9 @@ module.exports =
         resolvedPath = resolvedPath.replace(/\$PROJECT_NAME/g, projectName)
         resolvedPath = resolvedPath.replace(/\$PROJECT_PATH/g, projectPath)
     return resolvedPath
+
+  resolveMultiPaths: (targetMultiPath, filepath) ->
+    for targetPath in targetMultiPath.split(";")
+      resolvedPath = @resolvePath targetPath, filepath
+      if fs.existsSync(resolvedPath)
+        return resolvedPath

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -19,10 +19,10 @@ module.exports =
       title: 'Python Executable Path'
       type: 'string'
       default: 'python3'
-      description: '''Path to the executable of python.
+      description: '''Semicolon separated list of paths to Python.
       The optionals `$PROJECT_PATH` and `$PROJECT_NAME` variables can be used to resolve the path
       dynamically depending of the current project. For example:
-      `/home/user/.virtualenvs/$PROJECT_NAME/bin/python`.
+      `/home/user/.virtualenvs/$PROJECT_NAME/bin/python;python3`.
       '''
       order: 1
 


### PR DESCRIPTION
This is a feature that I more or less copied over from https://github.com/AtomLinter/linter-flake8. I need this feature in order to set up a default python version to use when no virtual environment is available for the current file (such as when looking at standard library files which happens sometimes when I'm using the hyperclick package from ide-python, as this suddenly takes you out of the current project).